### PR TITLE
Implement iteration over paragraph- and document-level scores

### DIFF
--- a/cocoscore/tagger/co_occurrence_score.py
+++ b/cocoscore/tagger/co_occurrence_score.py
@@ -68,7 +68,7 @@ def load_matches_file(matches_file_path, entities_file, first_type, second_type)
         matches_file.close()
 
 
-def load_score_file_iterator(score_dict):
+def load_sentence_score_iterator(score_dict):
     for entity_pair, pmid_paragraph_sentence_dict in score_dict.items():
         entity_1, entity_2 = entity_pair
         pmid_to_paragraphs = collections.defaultdict(set)
@@ -79,6 +79,14 @@ def load_score_file_iterator(score_dict):
             pmid_to_paragraphs[pmid].add(paragraph)
         for pmid in pmid_to_sentences:
             yield pmid, entity_1, entity_2, pmid_to_sentences[pmid], pmid_to_paragraphs[pmid]
+
+
+def load_paragraph_score_iterator(score_dict):
+    pass
+
+
+def load_document_score_iterator(score_dict):
+    pass
 
 
 def get_max_sentence_score(scores, sentence_co_mentions, pmid, entity_1, entity_2):
@@ -122,7 +130,7 @@ def get_weighted_counts(matches_file_path, sentence_scores, paragraph_scores, do
     if matches_file_path is not None:
         matches_iter = load_matches_file(matches_file_path, entities_file, first_type, second_type)
     else:
-        matches_iter = [load_score_file_iterator(sentence_scores)]
+        matches_iter = [load_sentence_score_iterator(sentence_scores)]
     for i, document_matches in enumerate(matches_iter):
         if i > 0 and i % 100000 == 0 and not silent:
             print('Document', i)
@@ -138,7 +146,7 @@ def get_weighted_counts(matches_file_path, sentence_scores, paragraph_scores, do
 
             if isinstance(paragraph_scores, dict) and not ignore_scores:
                 paragraph_score = get_max_paragraph_score(paragraph_scores, paragraph_co_mentions, pmid, entity_1,
-                                                         entity_2)
+                                                          entity_2)
             else:
                 if len(paragraph_co_mentions) > 0:
                     paragraph_score = 1

--- a/cocoscore/tagger/co_occurrence_score.py
+++ b/cocoscore/tagger/co_occurrence_score.py
@@ -82,11 +82,21 @@ def load_sentence_score_iterator(score_dict):
 
 
 def load_paragraph_score_iterator(score_dict):
-    pass
+    for entity_pair, pmid_paragraph_dict in score_dict.items():
+        entity_1, entity_2 = entity_pair
+        pmid_to_paragraphs = collections.defaultdict(set)
+        for pmid_paragraph, _ in pmid_paragraph_dict.items():
+            pmid, paragraph = pmid_paragraph
+            pmid_to_paragraphs[pmid].add(paragraph)
+        for pmid in pmid_to_paragraphs:
+            yield pmid, entity_1, entity_2, {}, pmid_to_paragraphs[pmid]
 
 
 def load_document_score_iterator(score_dict):
-    pass
+    for entity_pair, pmid_dict in score_dict.items():
+        entity_1, entity_2 = entity_pair
+        for pmid in pmid_dict.keys():
+            yield pmid, entity_1, entity_2, {}, {}
 
 
 def get_max_sentence_score(scores, sentence_co_mentions, pmid, entity_1, entity_2):
@@ -130,7 +140,13 @@ def get_weighted_counts(matches_file_path, sentence_scores, paragraph_scores, do
     if matches_file_path is not None:
         matches_iter = load_matches_file(matches_file_path, entities_file, first_type, second_type)
     else:
-        matches_iter = [load_sentence_score_iterator(sentence_scores)]
+        if sentence_scores is not None:
+            my_iterator = load_sentence_score_iterator(sentence_scores)
+        elif paragraph_scores is not None:
+            my_iterator = load_paragraph_score_iterator(paragraph_scores)
+        else:
+            my_iterator = load_document_score_iterator(document_scores)
+        matches_iter = [my_iterator]
     for i, document_matches in enumerate(matches_iter):
         if i > 0 and i % 100000 == 0 and not silent:
             print('Document', i)

--- a/cocoscore/tagger/co_occurrence_score.py
+++ b/cocoscore/tagger/co_occurrence_score.py
@@ -128,7 +128,7 @@ def get_document_score(scores, pmid, entity_1, entity_2):
     if (entity_1, entity_2) in scores and key in scores[(entity_1, entity_2)]:
         return scores[(entity_1, entity_2)][key]
     else:
-        # TODO return 0.5 and print message to debug logging if no document scores found?
+        # TODO return 0.5 and print message to debug logging if no document scores found? 
         pass
 
 

--- a/tests/tagger/test_co_occurrence_score.py
+++ b/tests/tagger/test_co_occurrence_score.py
@@ -64,6 +64,20 @@ class CooccurrenceTest(unittest.TestCase):
                               'C': 15,
                               None: 15.9 + 0.9 + 15.44 + 0.4 + 15}, weighted_counts)
 
+    def test_weighted_counts_paragraphs(self):
+        paragraph_scores = co_occurrence_score.load_paragraph_score_file(self.paragraph_score_file_path)
+        weighted_counts = co_occurrence_score.get_weighted_counts(None, None, paragraph_scores, None, None,
+                                                                  first_type=9606, second_type=-26,
+                                                                  document_weight=15.0, paragraph_weight=1.0,
+                                                                  sentence_weight=1.0)
+        self.assertDictEqual({('--D', 'A'): 15 + 1 + 0.9 + 15 + 1 + 0.4,
+                              ('B', 'C'): 15 + 1,
+                              'A': 15 + 1 + 0.9 + 15 + 1 + 0.4,
+                              '--D': 15 + 1 + 0.9 + 15 + 1 + 0.4,
+                              'B': 15 + 1,
+                              'C': 15 + 1,
+                              None: 15 + 1 + 0.9 + 15 + 1 + 0.4 + 15 + 1}, weighted_counts)
+
     def test_weighted_counts_sentences_paragraphs_documents(self):
         sentence_scores = co_occurrence_score.load_sentence_score_file(self.sentence_score_file_path)
         paragraph_scores = co_occurrence_score.load_paragraph_score_file(self.paragraph_score_file_path)
@@ -80,6 +94,38 @@ class CooccurrenceTest(unittest.TestCase):
                               'B': 3 * 2,
                               'C': 3 * 2,
                               None: 0.9 + 0.9 + 1 * 2 + 0.44 + 0.4 + 2 * 2 + 3 * 2}, weighted_counts)
+
+    def test_weighted_counts_documents(self):
+
+        document_scores = co_occurrence_score.load_document_score_file(self.document_score_file_path)
+        weighted_counts = co_occurrence_score.get_weighted_counts(None, None, None,
+                                                                  document_scores, None,
+                                                                  first_type=9606, second_type=-26,
+                                                                  document_weight=2.0, paragraph_weight=1.0,
+                                                                  sentence_weight=2.0)
+        self.assertDictEqual({('--D', 'A'): 1 + 2 + 1 * 2 + 1 + 2 + 2 * 2,
+                              ('B', 'C'): 1 + 2 + 3 * 2,
+                              'A': 1 + 2 + 1 * 2 + 1 + 2 + 2 * 2,
+                              '--D': 1 + 2 + 1 * 2 + 1 + 2 + 2 * 2,
+                              'B': 1 + 2 + 3 * 2,
+                              'C': 1 + 2 + 3 * 2,
+                              None: 1 + 2 + 1 * 2 + 1 + 2 + 2 * 2 +  + 2 + 3 * 2}, weighted_counts)
+
+    def test_weighted_counts_paragraphs_documents(self):
+        paragraph_scores = co_occurrence_score.load_paragraph_score_file(self.paragraph_score_file_path)
+        document_scores = co_occurrence_score.load_document_score_file(self.document_score_file_path)
+        weighted_counts = co_occurrence_score.get_weighted_counts(None, None, paragraph_scores,
+                                                                  document_scores, None,
+                                                                  first_type=9606, second_type=-26,
+                                                                  document_weight=2.0, paragraph_weight=1.0,
+                                                                  sentence_weight=1.0)
+        self.assertDictEqual({('--D', 'A'): 1 + 0.9 + 1 * 2 + 1 + 0.4 + 2 * 2,
+                              ('B', 'C'): 1 + 3 * 2,
+                              'A': 1 + 0.9 + 1 * 2 + 1 + 0.4 + 2 * 2,
+                              '--D': 1 + 0.9 + 1 * 2 + 1 + 0.4 + 2 * 2,
+                              'B': 1 + 3 * 2,
+                              'C': 1 + 3 * 2,
+                              None: 1 + 0.9 + 1 * 2 + 1 + 0.4 + 2 * 2 + 1 + 3 * 2}, weighted_counts)
 
     def test_co_occurrence_score_sentences(self):
         sentence_scores = co_occurrence_score.load_sentence_score_file(self.sentence_score_file_path)


### PR DESCRIPTION
In `tagger/co_occurrence_score.py`, this is to be used when no sentence-level scores are given.